### PR TITLE
Make upload-x86-jtag target flash only x86 core

### DIFF
--- a/scripts/flash-jtag.cfg
+++ b/scripts/flash-jtag.cfg
@@ -7,13 +7,11 @@ gdb_breakpoint_override hard
 cd images/firmware
 source partition.conf
 load_image   bootloader_quark.bin $boot_start_addr
-load_image   arc.bin $arc_start_addr
 load_image   quark.0.bin $quark0_start_addr
 load_image   quark.1.bin $quark1_start_addr
 load_image   FSRom.bin $rom_start_addr
 
 verify_image bootloader_quark.bin $boot_start_addr
-verify_image arc.bin $arc_start_addr
 verify_image quark.0.bin $quark0_start_addr
 verify_image quark.1.bin $quark1_start_addr
 verify_image FSRom.bin $rom_start_addr


### PR DESCRIPTION
This script originated from PVT-User flashpack which was intended to run after 
PVT-Factory flashpack. Since PVT-Factory flashpack put test ARC binary into ARC 
core, it was important for PVT-User flashpack to put a blank ARC binary to reset
the board into a clean state.

This script is now called as a part of make upload-x86-jtag target. In this 
context, it makes no sense to also flash ARC core.